### PR TITLE
fix(devenv.nix): added pre-commit as a dependency

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -13,6 +13,8 @@
     gnupg
     pinentry-curses
     git-cliff
+
+    pre-commit
     commitizen
 
     fastfetch


### PR DESCRIPTION
forgot to add this initially...usually installed with precommit.hooks